### PR TITLE
Solutions : expected struct `TryFromIntError`, found struct `anyhow::Error`

### DIFF
--- a/rust/src/ops.rs
+++ b/rust/src/ops.rs
@@ -4,6 +4,7 @@ use ripemd160::Ripemd160;
 use sha2::{Digest, Sha256, Sha512, Sha512Trunc256};
 use sha3::Sha3_512;
 use std::convert::TryInto;
+use std::num::TryFromIntError;
 
 use crate::helpers::{Hash, Result};
 use crate::ics23::{HashOp, InnerOp, LeafOp, LengthOp};
@@ -68,7 +69,7 @@ fn do_length(length: LengthOp, data: &[u8]) -> Result<Hash> {
 }
 
 fn proto_len(length: usize) -> Result<Hash> {
-    let size: u64 = length.try_into()?;
+    let size: u64 = length.try_into().map_err(|e : TryFromIntError | anyhow::anyhow!(e))?;
     let mut len = Hash::new();
     prost::encoding::encode_varint(size, &mut len);
     Ok(len)


### PR DESCRIPTION
> error[E0271]: type mismatch resolving `<u64 as TryFrom<usize>>::Error == anyhow::Error`
    --> /Users/davirain/.cargo/git/checkouts/ics23-fbd6714e79a75cb1/5a0206f/rust/src/ops.rs:71:28
     |
  71 |     let size: u64 = length.try_into()?;
     |                            ^^^^^^^^ expected struct `TryFromIntError`, found struct `anyhow::Error`

  >Compiling getrandom v0.2.3
  >For more information about this error, try `rustc --explain E0271`.
  error: could not compile `ics23` due to previous error
  warning: build failed, waiting for other jobs to finish...
  error: build failed

When I added ics23 to substrate for testing to see if the error reported by no_std was well supported.