### PR TITLE
Use explicit conversion to `anyhow::Error` to fix compilation in `no_std` mode

### DIFF
--- a/rust/src/ops.rs
+++ b/rust/src/ops.rs
@@ -68,7 +68,7 @@ fn do_length(length: LengthOp, data: &[u8]) -> Result<Hash> {
 }
 
 fn proto_len(length: usize) -> Result<Hash> {
-    let size: u64 = length.try_into()?;
+    let size: u64 = length.try_into().map_err(anyhow::Error::msg)?;
     let mut len = Hash::new();
     prost::encoding::encode_varint(size, &mut len);
     Ok(len)


### PR DESCRIPTION
Supersedes: #48

Context: https://github.com/confio/ics23/pull/48#issuecomment-954960745

> Since the ?-based error conversions would normally rely on the std::error::Error trait which is only available through std, no_std mode will require an explicit .map_err(Error::msg) when working with a non-Anyhow error type inside a function that returns Anyhow’s error type.
> https://docs.rs/anyhow/1.0.44/anyhow/#no-std-support

Re: https://github.com/confio/ics23/pull/48#issuecomment-955201946

I am unfortunately not able to add a proper no-std test harness at the moment, as the crate needs a bunch more work to be fully no-std compatible, eg. by removing or replacing `anyhow` (potentially with `flex-error`) since it's is not fully `no-std` compatible despite what their docs say. We have such a test harness in `ibc-rs` and we will try to port it over eventually and finish up the `no-std` work together with @DaviRain-Su who is the actual customer for this feature. We at Informal are only trying to enable Substrate to use the `ibc` crate in a no-std environment.

Reproducing the compilation error itself is not trivial either as it has only appeared for us when trying to `cargo publish` the `ibc` crate. It's unclear why this does not trigger when building without the `std` feature.

For now, we do not need full `no-std` support in ics23, just fixing this compilation error would already unblock the next release of Hermes :)