### PR TITLE
Check for placeholder nodes in proof verification

### DIFF
--- a/go/proof.go
+++ b/go/proof.go
@@ -314,7 +314,7 @@ func getPadding(spec *InnerSpec, branch int32) (minPrefix, maxPrefix, suffix int
 func leftBranchesAreEmpty(spec *InnerSpec, op *InnerOp, branch int32) bool {
 	idx := getPosition(spec.ChildOrder, branch)
 	// compare the prefix bytes with the appropriate number of empty children
-	leftChildren := len(spec.ChildOrder) - 1 - idx
+	leftChildren := idx
 	actualPrefix := len(op.Prefix) - leftChildren*int(spec.ChildSize)
 	if actualPrefix < 0 {
 		return false
@@ -332,11 +332,12 @@ func leftBranchesAreEmpty(spec *InnerSpec, op *InnerOp, branch int32) bool {
 // on the right side of this branch, ie. it's a valid placeholder on a rightmost path
 func rightBranchesAreEmpty(spec *InnerSpec, op *InnerOp, branch int32) bool {
 	idx := getPosition(spec.ChildOrder, branch)
+	rightBranches := len(spec.ChildOrder) - 1 - idx
 	// compare the suffix bytes with the appropriate number of empty children
-	if len(op.Suffix) != idx*int(spec.ChildSize) {
+	if len(op.Suffix) != rightBranches*int(spec.ChildSize) {
 		return false
 	}
-	for i := 0; i < idx; i++ {
+	for i := 0; i < rightBranches; i++ {
 		from := i * int(spec.ChildSize)
 		if !bytes.Equal(spec.EmptyChild, op.Suffix[from:from+int(spec.ChildSize)]) {
 			return false

--- a/go/proof.go
+++ b/go/proof.go
@@ -210,35 +210,27 @@ func (p *NonExistenceProof) Verify(spec *ProofSpec, root CommitmentRoot, key []b
 	return nil
 }
 
-// IsLeftMost returns true if this is the left-most path in the tree
+// IsLeftMost returns true if this is the left-most path in the tree, excluding placeholder (empty child) nodes
 func IsLeftMost(spec *InnerSpec, path []*InnerOp) bool {
 	minPrefix, maxPrefix, suffix := getPadding(spec, 0)
 
-	// ensure every step has a prefix and suffix defined to be leftmost
+	// ensure every step has a prefix and suffix defined to be leftmost, unless it is a placeholder node
 	for _, step := range path {
-		if !hasPadding(step, minPrefix, maxPrefix, suffix) {
-			// if this is a placeholder node, skip it
-			if leftBranchesAreEmpty(spec, step, 0) {
-				continue
-			}
+		if !hasPadding(step, minPrefix, maxPrefix, suffix) && !leftBranchesAreEmpty(spec, step, 0) {
 			return false
 		}
 	}
 	return true
 }
 
-// IsRightMost returns true if this is the left-most path in the tree
+// IsRightMost returns true if this is the left-most path in the tree, excluding placeholder (empty child) nodes
 func IsRightMost(spec *InnerSpec, path []*InnerOp) bool {
 	last := len(spec.ChildOrder) - 1
 	minPrefix, maxPrefix, suffix := getPadding(spec, int32(last))
 
-	// ensure every step has a prefix and suffix defined to be rightmost
+	// ensure every step has a prefix and suffix defined to be rightmost, unless it is a placeholder node
 	for _, step := range path {
-		if !hasPadding(step, minPrefix, maxPrefix, suffix) {
-			// if this is a placeholder node, skip it
-			if rightBranchesAreEmpty(spec, step, int32(last)) {
-				continue
-			}
+		if !hasPadding(step, minPrefix, maxPrefix, suffix) && !rightBranchesAreEmpty(spec, step, int32(last)) {
 			return false
 		}
 	}

--- a/go/proof.go
+++ b/go/proof.go
@@ -281,10 +281,6 @@ func isLeftStep(spec *InnerSpec, left *InnerOp, right *InnerOp) bool {
 		panic(err)
 	}
 
-	// for idx := leftidx + 1; idx != rightidx; idx++ {
-	// leftBranchesAreEmpty()
-	// }
-
 	// TODO: is it possible there are empty (nil) children???
 	return rightidx == leftidx+1
 }

--- a/go/proof_data_test.go
+++ b/go/proof_data_test.go
@@ -105,7 +105,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 			},
 			Spec:    SpecWithEmptyChild,
 			IsLeft:  true,
-			IsRight: false,
+			IsRight: true,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
@@ -114,7 +114,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
 			Spec:    SpecWithEmptyChild,
-			IsLeft:  false,
+			IsLeft:  true,
 			IsRight: true,
 		},
 		// non-empty cases
@@ -126,7 +126,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 			},
 			Spec:    SpecWithEmptyChild,
 			IsLeft:  false,
-			IsRight: false,
+			IsRight: true,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
@@ -135,7 +135,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
 			Spec:    SpecWithEmptyChild,
-			IsLeft:  false,
+			IsLeft:  true,
 			IsRight: false,
 		},
 		EmptyBranchTestStruct{
@@ -146,7 +146,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 			},
 			Spec:    SpecWithEmptyChild,
 			IsLeft:  false,
-			IsRight: false,
+			IsRight: true,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
@@ -155,7 +155,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
 			Spec:    SpecWithEmptyChild,
-			IsLeft:  false,
+			IsLeft:  true,
 			IsRight: false,
 		},
 		// some cases using a spec with no empty child
@@ -167,7 +167,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 			},
 			Spec:    TendermintSpec,
 			IsLeft:  false,
-			IsRight: false,
+			IsRight: true,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
@@ -176,7 +176,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 				Hash:   TendermintSpec.InnerSpec.Hash,
 			},
 			Spec:    TendermintSpec,
-			IsLeft:  false,
+			IsLeft:  true,
 			IsRight: false,
 		},
 	}

--- a/go/proof_data_test.go
+++ b/go/proof_data_test.go
@@ -105,7 +105,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 			},
 			Spec:    SpecWithEmptyChild,
 			IsLeft:  true,
-			IsRight: true,
+			IsRight: false,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
@@ -114,7 +114,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
 			Spec:    SpecWithEmptyChild,
-			IsLeft:  true,
+			IsLeft:  false,
 			IsRight: true,
 		},
 		// non-empty cases
@@ -126,7 +126,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 			},
 			Spec:    SpecWithEmptyChild,
 			IsLeft:  false,
-			IsRight: true,
+			IsRight: false,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
@@ -135,7 +135,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
 			Spec:    SpecWithEmptyChild,
-			IsLeft:  true,
+			IsLeft:  false,
 			IsRight: false,
 		},
 		EmptyBranchTestStruct{
@@ -146,7 +146,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 			},
 			Spec:    SpecWithEmptyChild,
 			IsLeft:  false,
-			IsRight: true,
+			IsRight: false,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
@@ -155,7 +155,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
 			Spec:    SpecWithEmptyChild,
-			IsLeft:  true,
+			IsLeft:  false,
 			IsRight: false,
 		},
 		// some cases using a spec with no empty child
@@ -167,7 +167,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 			},
 			Spec:    TendermintSpec,
 			IsLeft:  false,
-			IsRight: true,
+			IsRight: false,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
@@ -176,7 +176,7 @@ func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
 				Hash:   TendermintSpec.InnerSpec.Hash,
 			},
 			Spec:    TendermintSpec,
-			IsLeft:  true,
+			IsLeft:  false,
 			IsRight: false,
 		},
 	}

--- a/go/proof_data_test.go
+++ b/go/proof_data_test.go
@@ -69,3 +69,135 @@ func CheckAgainstSpecTestData(t *testing.T) map[string]CheckAgainstSpecTestStruc
 	}
 	return cases
 }
+
+type EmptyBranchTestStruct struct {
+	Op     *InnerOp
+	Spec   *InnerSpec
+	IsTrue bool
+	IsLeft bool
+}
+
+var InnerSpecWithEmptyChild = InnerSpec{
+	ChildOrder:      []int32{0, 1},
+	ChildSize:       32,
+	MinPrefixLength: 1,
+	MaxPrefixLength: 1,
+	EmptyChild:      []byte("32_empty_child_placeholder_bytes"),
+	Hash:            HashOp_SHA256,
+}
+
+func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
+	return []EmptyBranchTestStruct{
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: []byte{1},
+				Suffix: InnerSpecWithEmptyChild.EmptyChild,
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: true,
+			IsLeft: false,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: append([]byte{1}, make([]byte, 32)...),
+				Suffix: InnerSpecWithEmptyChild.EmptyChild,
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: true,
+			IsLeft: false,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: []byte{1},
+				Suffix: make([]byte, 32),
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: false,
+			IsLeft: false,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: []byte{1},
+				Suffix: nil,
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: false,
+			IsLeft: false,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: []byte{1},
+				Suffix: append(InnerSpecWithEmptyChild.EmptyChild, []byte("xxxx")...),
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: false,
+			IsLeft: false,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: []byte{1},
+				Suffix: nil,
+			},
+			Spec:   IavlSpec.InnerSpec,
+			IsTrue: false,
+			IsLeft: false,
+		},
+
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: append([]byte{1}, InnerSpecWithEmptyChild.EmptyChild...),
+				Suffix: nil,
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: true,
+			IsLeft: true,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: append([]byte{1}, InnerSpecWithEmptyChild.EmptyChild...),
+				Suffix: make([]byte, 32),
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: true,
+			IsLeft: true,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: append([]byte{1}, make([]byte, 32)...),
+				Suffix: nil,
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: false,
+			IsLeft: true,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: []byte{1},
+				Suffix: nil,
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: false,
+			IsLeft: true,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: append(
+					append([]byte{1}, InnerSpecWithEmptyChild.EmptyChild...),
+					[]byte("xxxx")...),
+				Suffix: nil,
+			},
+			Spec:   &InnerSpecWithEmptyChild,
+			IsTrue: false,
+			IsLeft: true,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: []byte{1},
+				Suffix: nil,
+			},
+			Spec:   IavlSpec.InnerSpec,
+			IsTrue: false,
+			IsLeft: true,
+		},
+	}
+}

--- a/go/proof_data_test.go
+++ b/go/proof_data_test.go
@@ -70,134 +70,114 @@ func CheckAgainstSpecTestData(t *testing.T) map[string]CheckAgainstSpecTestStruc
 	return cases
 }
 
-type EmptyBranchTestStruct struct {
-	Op     *InnerOp
-	Spec   *InnerSpec
-	IsTrue bool
-	IsLeft bool
+var SpecWithEmptyChild = &ProofSpec{
+	LeafSpec: &LeafOp{
+		Prefix:       []byte{0},
+		Hash:         HashOp_SHA256,
+		PrehashValue: HashOp_SHA256,
+	},
+	InnerSpec: &InnerSpec{
+		ChildOrder:      []int32{0, 1},
+		ChildSize:       32,
+		MinPrefixLength: 1,
+		MaxPrefixLength: 1,
+		EmptyChild:      []byte("32_empty_child_placeholder_bytes"),
+		Hash:            HashOp_SHA256,
+	},
 }
 
-var InnerSpecWithEmptyChild = InnerSpec{
-	ChildOrder:      []int32{0, 1},
-	ChildSize:       32,
-	MinPrefixLength: 1,
-	MaxPrefixLength: 1,
-	EmptyChild:      []byte("32_empty_child_placeholder_bytes"),
-	Hash:            HashOp_SHA256,
+type EmptyBranchTestStruct struct {
+	Op      *InnerOp
+	Spec    *ProofSpec
+	IsLeft  bool
+	IsRight bool
 }
 
 func EmptyBranchTestData(t *testing.T) []EmptyBranchTestStruct {
+	var emptyChild = SpecWithEmptyChild.InnerSpec.EmptyChild
+
 	return []EmptyBranchTestStruct{
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
-				Prefix: []byte{1},
-				Suffix: InnerSpecWithEmptyChild.EmptyChild,
+				Prefix: append([]byte{1}, emptyChild...),
+				Suffix: nil,
+				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: true,
-			IsLeft: false,
+			Spec:    SpecWithEmptyChild,
+			IsLeft:  true,
+			IsRight: false,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
-				Prefix: append([]byte{1}, make([]byte, 32)...),
-				Suffix: InnerSpecWithEmptyChild.EmptyChild,
+				Prefix: []byte{1},
+				Suffix: emptyChild,
+				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: true,
-			IsLeft: false,
+			Spec:    SpecWithEmptyChild,
+			IsLeft:  false,
+			IsRight: true,
+		},
+		// non-empty cases
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: append([]byte{1}, make([]byte, 32)...),
+				Suffix: nil,
+				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
+			},
+			Spec:    SpecWithEmptyChild,
+			IsLeft:  false,
+			IsRight: false,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
 				Prefix: []byte{1},
 				Suffix: make([]byte, 32),
+				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: false,
-			IsLeft: false,
+			Spec:    SpecWithEmptyChild,
+			IsLeft:  false,
+			IsRight: false,
+		},
+		EmptyBranchTestStruct{
+			Op: &InnerOp{
+				Prefix: append(append([]byte{1}, emptyChild[0:28]...), []byte("xxxx")...),
+				Suffix: nil,
+				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
+			},
+			Spec:    SpecWithEmptyChild,
+			IsLeft:  false,
+			IsRight: false,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
 				Prefix: []byte{1},
-				Suffix: nil,
+				Suffix: append(append([]byte(nil), emptyChild[0:28]...), []byte("xxxx")...),
+				Hash:   SpecWithEmptyChild.InnerSpec.Hash,
 			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: false,
-			IsLeft: false,
+			Spec:    SpecWithEmptyChild,
+			IsLeft:  false,
+			IsRight: false,
 		},
-		EmptyBranchTestStruct{
-			Op: &InnerOp{
-				Prefix: []byte{1},
-				Suffix: append(InnerSpecWithEmptyChild.EmptyChild, []byte("xxxx")...),
-			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: false,
-			IsLeft: false,
-		},
-		EmptyBranchTestStruct{
-			Op: &InnerOp{
-				Prefix: []byte{1},
-				Suffix: nil,
-			},
-			Spec:   IavlSpec.InnerSpec,
-			IsTrue: false,
-			IsLeft: false,
-		},
-
-		EmptyBranchTestStruct{
-			Op: &InnerOp{
-				Prefix: append([]byte{1}, InnerSpecWithEmptyChild.EmptyChild...),
-				Suffix: nil,
-			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: true,
-			IsLeft: true,
-		},
-		EmptyBranchTestStruct{
-			Op: &InnerOp{
-				Prefix: append([]byte{1}, InnerSpecWithEmptyChild.EmptyChild...),
-				Suffix: make([]byte, 32),
-			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: true,
-			IsLeft: true,
-		},
+		// some cases using a spec with no empty child
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
 				Prefix: append([]byte{1}, make([]byte, 32)...),
 				Suffix: nil,
+				Hash:   TendermintSpec.InnerSpec.Hash,
 			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: false,
-			IsLeft: true,
+			Spec:    TendermintSpec,
+			IsLeft:  false,
+			IsRight: false,
 		},
 		EmptyBranchTestStruct{
 			Op: &InnerOp{
 				Prefix: []byte{1},
-				Suffix: nil,
+				Suffix: make([]byte, 32),
+				Hash:   TendermintSpec.InnerSpec.Hash,
 			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: false,
-			IsLeft: true,
-		},
-		EmptyBranchTestStruct{
-			Op: &InnerOp{
-				Prefix: append(
-					append([]byte{1}, InnerSpecWithEmptyChild.EmptyChild...),
-					[]byte("xxxx")...),
-				Suffix: nil,
-			},
-			Spec:   &InnerSpecWithEmptyChild,
-			IsTrue: false,
-			IsLeft: true,
-		},
-		EmptyBranchTestStruct{
-			Op: &InnerOp{
-				Prefix: []byte{1},
-				Suffix: nil,
-			},
-			Spec:   IavlSpec.InnerSpec,
-			IsTrue: false,
-			IsLeft: true,
+			Spec:    TendermintSpec,
+			IsLeft:  false,
+			IsRight: false,
 		},
 	}
 }

--- a/go/proof_test.go
+++ b/go/proof_test.go
@@ -63,10 +63,14 @@ func TestEmptyBranch(t *testing.T) {
 			if err := tc.Op.CheckAgainstSpec(tc.Spec); err != nil {
 				t.Errorf("Invalid InnerOp: %v", err)
 			}
-			if leftBranchesAreEmpty(tc.Spec.InnerSpec, tc.Op, 0) != tc.IsLeft {
+			order, err := orderFromPadding(tc.Spec.InnerSpec, tc.Op)
+			if err != nil {
+				t.Errorf("Cannot get orderFromPadding: %v", err)
+			}
+			if leftBranchesAreEmpty(tc.Spec.InnerSpec, tc.Op, order) != tc.IsLeft {
 				t.Errorf("Expected leftBranchesAreEmpty to be %t but it wasn't", tc.IsLeft)
 			}
-			if rightBranchesAreEmpty(tc.Spec.InnerSpec, tc.Op, 1) != tc.IsRight {
+			if rightBranchesAreEmpty(tc.Spec.InnerSpec, tc.Op, order) != tc.IsRight {
 				t.Errorf("Expected rightBranchesAreEmpty to be %t but it wasn't", tc.IsRight)
 			}
 		})

--- a/go/proof_test.go
+++ b/go/proof_test.go
@@ -54,3 +54,21 @@ func TestCheckAgainstSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestEmptyBranch(t *testing.T) {
+	cases := EmptyBranchTestData(t)
+
+	for i, tc := range cases {
+		var res bool
+		if tc.IsLeft {
+			res = leftBranchesAreEmpty(tc.Spec, tc.Op, 0)
+		} else {
+			res = rightBranchesAreEmpty(tc.Spec, tc.Op, 1)
+		}
+		if tc.IsTrue && !res {
+			t.Errorf("Result should be true, but was false (i=%v)", i)
+		} else if !tc.IsTrue && res {
+			t.Errorf("Result should be false, but was true (i=%v)", i)
+		}
+	}
+}

--- a/go/proof_test.go
+++ b/go/proof_test.go
@@ -58,17 +58,17 @@ func TestCheckAgainstSpec(t *testing.T) {
 func TestEmptyBranch(t *testing.T) {
 	cases := EmptyBranchTestData(t)
 
-	for i, tc := range cases {
-		var res bool
-		if tc.IsLeft {
-			res = leftBranchesAreEmpty(tc.Spec, tc.Op, 0)
-		} else {
-			res = rightBranchesAreEmpty(tc.Spec, tc.Op, 1)
-		}
-		if tc.IsTrue && !res {
-			t.Errorf("Result should be true, but was false (i=%v)", i)
-		} else if !tc.IsTrue && res {
-			t.Errorf("Result should be false, but was true (i=%v)", i)
-		}
+	for _, tc := range cases {
+		t.Run("case", func(t *testing.T) {
+			if err := tc.Op.CheckAgainstSpec(tc.Spec); err != nil {
+				t.Errorf("Invalid InnerOp: %v", err)
+			}
+			if leftBranchesAreEmpty(tc.Spec.InnerSpec, tc.Op, 0) != tc.IsLeft {
+				t.Errorf("Expected leftBranchesAreEmpty to be %t but it wasn't", tc.IsLeft)
+			}
+			if rightBranchesAreEmpty(tc.Spec.InnerSpec, tc.Op, 1) != tc.IsRight {
+				t.Errorf("Expected rightBranchesAreEmpty to be %t but it wasn't", tc.IsRight)
+			}
+		})
 	}
 }

--- a/go/vectors_test.go
+++ b/go/vectors_test.go
@@ -48,23 +48,26 @@ func TestBatchVectors(t *testing.T) {
 				// non-existence
 				valid := VerifyNonMembership(tc.Spec, tc.Ref.RootHash, tc.Proof, tc.Ref.Key)
 				if valid == tc.Invalid {
-					t.Fatalf("Expected proof validity: %t", !tc.Invalid)
+					t.Logf("name: %+v", name)
+					t.Logf("ref: %+v", tc.Ref)
+					t.Logf("spec: %+v", tc.Spec)
+					t.Errorf("Expected proof validity: %t", !tc.Invalid)
 				}
 				keys := [][]byte{tc.Ref.Key}
 				valid = BatchVerifyNonMembership(tc.Spec, tc.Ref.RootHash, tc.Proof, keys)
 				if valid == tc.Invalid {
-					t.Fatalf("Expected batch proof validity: %t", !tc.Invalid)
+					t.Errorf("Expected batch proof validity: %t", !tc.Invalid)
 				}
 			} else {
 				valid := VerifyMembership(tc.Spec, tc.Ref.RootHash, tc.Proof, tc.Ref.Key, tc.Ref.Value)
 				if valid == tc.Invalid {
-					t.Fatalf("Expected proof validity: %t", !tc.Invalid)
+					t.Errorf("Expected proof validity: %t", !tc.Invalid)
 				}
 				items := make(map[string][]byte)
 				items[string(tc.Ref.Key)] = tc.Ref.Value
 				valid = BatchVerifyMembership(tc.Spec, tc.Ref.RootHash, tc.Proof, items)
 				if valid == tc.Invalid {
-					t.Fatalf("Expected batch proof validity: %t", !tc.Invalid)
+					t.Errorf("Expected batch proof validity: %t", !tc.Invalid)
 				}
 			}
 		})


### PR DESCRIPTION
Certain proofs (like those for a SMT) can contain empty nodes which are equal to the `EmptyChild`, but currently these will cause verification to fail for non-existence proofs if they appear where a real sibling node would be invalid, i.e. on a path that must be the leftmost or rightmost path of a subtree.

This adds a check to detect and ignore such nodes during verification of left- and rightmost paths. This will be needed in order to support SMT proofs in https://github.com/confio/ics23/pull/57.