### PR TITLE
Update TypeScript to 4.5 and target to es2017

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -45,7 +45,7 @@
     "prettier": "^2.5.1",
     "shx": "^0.3.4",
     "source-map-support": "^0.5.16",
-    "typescript": "^3.8.3"
+    "typescript": "~4.5"
   },
   "dependencies": {
     "@noble/hashes": "^1.0.0",

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -19,8 +19,8 @@
     "removeComments": false,
     "sourceMap": true,
     "strict": true,
-    "target": "es6",
-    "lib": ["es6"],
+    "target": "es2017",
+    "lib": ["es2017"],
     "typeRoots": [
       "./node_modules/@types",
     ]

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1579,10 +1579,10 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@~4.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
es2017 should easily be supported by all potential users. We will now migrate from es2017 to es2018 in CosmJS but we can take it easy here.

The TS upgrade does not seem to cause any trouble, nice.