### PR TITLE
Handle empty with custom order

### DIFF
--- a/go/proof.go
+++ b/go/proof.go
@@ -348,7 +348,8 @@ func leftBranchesAreEmpty(spec *InnerSpec, op *InnerOp) bool {
 		return false
 	}
 	for i := 0; i < leftBranches; i++ {
-		from := actualPrefix + i*int(spec.ChildSize)
+		idx := getPosition(spec.ChildOrder, int32(i))
+		from := actualPrefix + idx*int(spec.ChildSize)
 		if !bytes.Equal(spec.EmptyChild, op.Prefix[from:from+int(spec.ChildSize)]) {
 			return false
 		}
@@ -373,7 +374,8 @@ func rightBranchesAreEmpty(spec *InnerSpec, op *InnerOp) bool {
 		return false // sanity check
 	}
 	for i := 0; i < rightBranches; i++ {
-		from := i * int(spec.ChildSize)
+		idx := getPosition(spec.ChildOrder, int32(i))
+		from := idx * int(spec.ChildSize)
 		if !bytes.Equal(spec.EmptyChild, op.Suffix[from:from+int(spec.ChildSize)]) {
 			return false
 		}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ics23"
-version = "0.7.0-rc"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ics23"
-version = "0.7.0-rc"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 exclude = ["codegen"]

--- a/rust/src/verify.rs
+++ b/rust/src/verify.rs
@@ -278,7 +278,9 @@ fn left_branches_are_empty(spec: &ics23::InnerSpec, op: &ics23::InnerOp) -> Resu
         _ => return Ok(false),
     };
     for i in 0..left_branches {
-        let from = actual_prefix + i * child_size;
+        let idx = spec.child_order.iter().find(|&&x| x == i as i32).unwrap();
+        let idx = *idx as usize;
+        let from = actual_prefix + idx * child_size;
         if spec.empty_child != op.prefix[from..from + child_size] {
             return Ok(false);
         }
@@ -300,7 +302,9 @@ fn right_branches_are_empty(spec: &ics23::InnerSpec, op: &ics23::InnerOp) -> Res
         return Ok(false);
     }
     for i in 0..right_branches {
-        let from = i * spec.child_size as usize;
+        let idx = spec.child_order.iter().find(|&&x| x == i as i32).unwrap();
+        let idx = *idx as usize;
+        let from = idx * spec.child_size as usize;
         if spec.empty_child != op.suffix[from..from + spec.child_size as usize] {
             return Ok(false);
         }


### PR DESCRIPTION
Make sure left/right_branches_are_empty code properly accounts for custom ordering (when branches are not in lexographical order).