### PR TITLE
Typo fix ops.go

### DIFF
--- a/go/ops.go
+++ b/go/ops.go
@@ -232,7 +232,7 @@ func (op *InnerOp) CheckAgainstSpec(spec *ProofSpec, b int) error {
 	return nil
 }
 
-// doHash will preform the specified hash on the preimage.
+// doHash will perform the specified hash on the preimage.
 // if hashOp == NONE, it will return an error (use doHashOrNoop if you want different behavior)
 func doHash(hashOp HashOp, preimage []byte) ([]byte, error) {
 	switch hashOp {


### PR DESCRIPTION
## Description

This pull request fixes a typo in the `ops.go` file:  
- Corrected "preform" to "perform" in the function comment for `doHash`.

## Changes Made
- **File Modified**: `ops.go`
  - Updated the comment:  
    From: `doHash will preform the specified hash on the preimage.`  
    To: `doHash will perform the specified hash on the preimage.`

## Rationale
Fixing typos in comments improves code clarity and professionalism, ensuring the documentation is accurate and easy to understand for developers.

## Checklist
- [x] Verified that the typo fix does not affect the code logic or functionality.
- [x] Ensured no additional typos exist in the surrounding code.
- [x] Reviewed the repository's security policy.

## Notes
- Contributions align with the repository's security policy.
- Allowing edits by maintainers for any required adjustments.

Let me know if there are further changes or improvements needed!
